### PR TITLE
Add interface.env() for retrieving local environment

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -22,6 +22,12 @@ module.exports = class Interface {
     ENV = this.environment = environment
   }
 
+
+  // FIXME: this shouldn't be needed
+  get env () {
+    return ENV
+  }
+
   setModule (mod) {
     this.module = MOD = mod
   }


### PR DESCRIPTION
Workaround for issue with `this` in Interface. Exports the ENV.
